### PR TITLE
fix js-api-w: creating Legend w/ null cntnr ref

### DIFF
--- a/samples/widgets/js-api-widget/src/runtime/widget.tsx
+++ b/samples/widgets/js-api-widget/src/runtime/widget.tsx
@@ -17,12 +17,12 @@
   A copy of the license is available in the repository's
   LICENSE file.
 */
-import {React, AllWidgetProps} from 'jimu-core';
+import { React, AllWidgetProps } from 'jimu-core';
 import { JimuMapViewComponent, JimuMapView } from 'jimu-arcgis';
 import Legend = require('esri/widgets/Legend');
 import LegendVM = require('esri/widgets/Legend/LegendViewModel');
 
-interface State{
+interface State {
   legendWidgetVM: LegendVM;
   layerInfo: any
 }
@@ -35,55 +35,55 @@ export default class Widget extends React.PureComponent<AllWidgetProps<{}>, Stat
 
   watchHandle: __esri.Handle;
 
-  constructor(props){
+  constructor(props) {
     super(props);
-    this.state = {legendWidgetVM: null, layerInfo: null}
+    this.state = { legendWidgetVM: null, layerInfo: null }
     this.apiWidgetContainer = React.createRef();
   }
 
-  componentDidMount(){
+  componentDidMount() {
     this.createAPIWidget();
   }
 
-  componentWillUnmount(){
-    if(this.legendWidget){
+  componentWillUnmount() {
+    if (this.legendWidget) {
       this.legendWidget.destroy();
       this.legendWidget = null;
     }
 
-    if(this.state.legendWidgetVM){
+    if (this.state.legendWidgetVM) {
       this.state.legendWidgetVM.destroy();
       this.setState({
         legendWidgetVM: null
       })
     }
 
-    if(this.watchHandle){
+    if (this.watchHandle) {
       this.watchHandle.remove();
       this.watchHandle = null;
     }
   }
 
   onActiveViewChange = (jimuMapView: JimuMapView) => {
-    if(!(jimuMapView && jimuMapView.view)){
+    if (!(jimuMapView && jimuMapView.view)) {
       return;
     }
     this.mapView = jimuMapView.view;
     this.createAPIWidget();
   }
 
-  createAPIWidget(){
-    if(!this.mapView){
+  createAPIWidget() {
+    if (!this.mapView) {
       return;
     }
-    if(!this.legendWidget){
+    if (!this.legendWidget && this.apiWidgetContainer.current) {  // ensure ref.current is not null because it's being called from onActiveViewChange() before DOM is completely mounted
       this.legendWidget = new Legend({
         view: this.mapView,
         container: this.apiWidgetContainer.current
       })
     }
 
-    if(!this.state.legendWidgetVM){
+    if (!this.state.legendWidgetVM) {
       const vm = new LegendVM({
         view: this.mapView,
       });
@@ -99,25 +99,25 @@ export default class Widget extends React.PureComponent<AllWidgetProps<{}>, Stat
     }
   }
 
-  render(){
-    if(!this.isConfigured()){
+  render() {
+    if (!this.isConfigured()) {
       return 'Select a map';
     }
 
-    return <div className="widget-use-map-view" style={{width: '100%', height: '100%', overflow: 'hidden'}}>
+    return <div className="widget-use-map-view" style={{ width: '100%', height: '100%', overflow: 'hidden' }}>
       <h3>
         This widget demonstrates how to use a widget (Legend) from the ArcGIS JS API.
       </h3>
 
       <JimuMapViewComponent useMapWidgetIds={this.props.useMapWidgetIds} onActiveViewChange={this.onActiveViewChange}></JimuMapViewComponent>
 
-      <hr/>
+      <hr />
       <h4>This uses the ViewModel.</h4>
       <div>
         Layer title: {this.state.layerInfo && this.state.layerInfo.title}
       </div>
 
-      <hr/>
+      <hr />
       <h4>This shows the Legend widget.</h4>
       <div ref={this.apiWidgetContainer}></div>
     </div>;


### PR DESCRIPTION
Hey guys, 
the js-api-widget has an issue when I use it in my dev edition of the ExB: **createAPIWidget() being called from onActiveViewChange() before DOM is completely mounted**, so the Legend widget is created with a null ref as its container and does not work. The legendWidget class variable however is filled, so it's also not updated when the DOM is finally there and createAPIWidget() runs through again from componentDidMount(). Checking that the ref is not null before creating the widget fixes the issue.
Cheers
Nik