### PR TITLE
add height to allow scroll

### DIFF
--- a/samples/widgets/editor/src/runtime/widget.tsx
+++ b/samples/widgets/editor/src/runtime/widget.tsx
@@ -111,7 +111,7 @@ export default class Widget extends React.PureComponent<AllWidgetProps<{}>, Stat
         className="widget-js-api-editor"
         style={{ height: "100%" , overflow: "auto" }}
       >
-       <div className="here" ref={this.myRef}>
+       <div ref={this.myRef}>
           <style>
             {css}
           </style>

--- a/samples/widgets/editor/src/runtime/widget.tsx
+++ b/samples/widgets/editor/src/runtime/widget.tsx
@@ -109,9 +109,13 @@ export default class Widget extends React.PureComponent<AllWidgetProps<{}>, Stat
     return (
       <div
         className="widget-js-api-editor"
-      css={[`height: "100%"; overflow: "auto";`, css]}
-    >
-     <div ref={this.myRef}></div>
+        style={{ height: "100%" , overflow: "auto" }}
+      >
+       <div className="here" ref={this.myRef}>
+          <style>
+            {css}
+          </style>
+        </div>
         {mvc}
       </div>
     );


### PR DESCRIPTION
This adds height if the widget is not full size, which allows the entire widget to scroll.  This was implemented by @shawnmgoulet 