### PR TITLE
Set default font parameters for demo-theme 

### DIFF
--- a/themes/demo-theme/manifest.json
+++ b/themes/demo-theme/manifest.json
@@ -3,6 +3,10 @@
   "label": "Demo Theme",
   "type": "theme",
   "thumbnails ": [],
+  "font": {
+    "fontFamily": "Avenir Next",
+    "color": "#484848"
+  },
   "version": "1.13.0",
   "exbVersion": "1.13.0",
   "author": "Esri R&D Center Beijing",


### PR DESCRIPTION
# Set default font parameters for demo-theme 

Prevent the theme name from being displayed in the theme selection bar (because the background color and text color are both white by default)

## before
<img width="1161" alt="image" src="https://github.com/Esri/arcgis-experience-builder-sdk-resources/assets/16833909/64f2b363-2bcc-4d32-9f51-f2b37ead6511">

## after
<img width="1404" alt="image" src="https://github.com/Esri/arcgis-experience-builder-sdk-resources/assets/16833909/22b496db-0375-48f7-a87b-4fa84485b535">
