### PR TITLE
Npm install subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ cd client
 git clone git@github.com:Esri/arcgis-experience-builder-sdk-resources.git sdk-sample
 ```
 
+Some widgets depend on 3rd party NPM packages, which need to be installed before compiling. These widgets have their own ``package.json`` in their root folder. Either navigate to the particular folders and execute ``npm i`` in there or run the script ``npm run install-subfolders`` right in the repository root. This will scan through the widget folders and install all dependencies.
+
+
 ## Requirements
 
 ## Resources

--- a/npm-install-subfolders.js
+++ b/npm-install-subfolders.js
@@ -1,0 +1,43 @@
+const { execSync } = require('child_process');
+const { readdirSync, statSync } = require('fs');
+const { join, resolve } = require('path');
+
+const rootDir = resolve('./widgets'); // Ensure rootDir is an absolute path
+const initialDir = process.cwd(); // Store the initial working directory
+
+function findDirectSubfolders(dir) {
+    const subfolders = [];
+    const items = readdirSync(dir);
+
+    items.forEach(item => {
+        const fullPath = join(dir, item);
+        if (statSync(fullPath).isDirectory()) {
+            // Check if the directory contains a package.json file
+            if (readdirSync(fullPath).includes('package.json')) {
+                subfolders.push(fullPath);
+            }
+        }
+    });
+
+    return subfolders;
+}
+
+function installInSubfolders(subfolders) {
+    subfolders.forEach(folder => {
+        try {
+            console.log(`Installing npm packages in ${folder}...`);
+            process.chdir(folder);
+            execSync('npm install', { stdio: 'inherit' });
+        } catch (error) {
+            console.error(`Failed to install in ${folder}: ${error}`);
+            // process.exit(1);
+        } finally {
+            process.chdir(initialDir); // Always return to the initial directory
+        }
+    });
+}
+
+const subfolders = findDirectSubfolders(rootDir);
+installInSubfolders(subfolders);
+
+console.log('npm install completed in all direct subfolders.');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "arcgis-experience-builder-sdk-resources",
+  "version": "1.13",
+  "description": "arcgis-experience-builder-sdk-resources",
+  "main": "",
+  "scripts": {
+    "install-subfolders": "node npm-install-subfolders.js"
+  },
+  "author": ""
+}

--- a/widgets/react-data-grid/package-lock.json
+++ b/widgets/react-data-grid/package-lock.json
@@ -1,30 +1,44 @@
 {
   "name": "react-data-grid-widget",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "object-assign": {
+  "packages": {
+    "": {
+      "name": "react-data-grid-widget",
+      "version": "1.0.0",
+      "dependencies": {
+        "react-data-grid": "^6.1.0"
+      }
+    },
+    "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "react-data-grid": {
+    "node_modules/react-data-grid": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-6.1.0.tgz",
       "integrity": "sha512-N1UtiHvsowEPzhx0VPqQKvGgSza/YNljczbisFDGMjawiGApS2taMv7h+EDXDx49CdaA6ur4eYS0z10x63IUpw==",
-      "requires": {
+      "dependencies": {
         "object-assign": "^4.1.1",
         "react-is-deprecated": "^0.1.2",
         "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0",
+        "react-dom": "^16.0.0"
       }
     },
-    "react-is-deprecated": {
+    "node_modules/react-is-deprecated": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/react-is-deprecated/-/react-is-deprecated-0.1.2.tgz",
       "integrity": "sha1-MBFI+G6kKP6OZz7KejchYLdXnb0="
     },
-    "shallowequal": {
+    "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="

--- a/widgets/show-record-id/manifest.json
+++ b/widgets/show-record-id/manifest.json
@@ -13,8 +13,8 @@
     {
       "name": "showId",
       "label": "show id",
-      "uri": "data-actions/show-id"
-    }
+      "uri": "data-actions/show-id",
+      "icon": "icon.svg"
   ],
   "translatedLocales": [
     "en"

--- a/widgets/show-record-id/manifest.json
+++ b/widgets/show-record-id/manifest.json
@@ -15,6 +15,7 @@
       "label": "show id",
       "uri": "data-actions/show-id",
       "icon": "icon.svg"
+    }
   ],
   "translatedLocales": [
     "en"


### PR DESCRIPTION
Added a script in root to scan widget folders for ``package.json`` files and ``npm i`` all of those. For now, this only concerns ``react-data-grid``, but other widgets might incorporate 3rd party packaged in the future. This is a great way to avoid manually looking for ``package.json``s in all subfolders.