### PR TITLE
Fix get map coordinates

### DIFF
--- a/widgets/get-map-coordinates-class/manifest.json
+++ b/widgets/get-map-coordinates-class/manifest.json
@@ -2,6 +2,7 @@
   "name": "get-map-coordinates-class",
   "label": "Get Map Coordinates (Class)",
   "type": "widget",
+  "dependency": "jimu-arcgis",
   "version": "1.13.0",
   "exbVersion": "1.13.0",
   "author": "Esri R&D Center Beijing",

--- a/widgets/get-map-coordinates-class/src/runtime/widget.tsx
+++ b/widgets/get-map-coordinates-class/src/runtime/widget.tsx
@@ -52,7 +52,7 @@ IState
     if (point.spatialReference.isWGS84 || point.spatialReference.isWebMercator) {
       return point
     }
-    if (!projection.isLoaded) {
+    if (!projection.isLoaded()) {
       await projection.load()
     }
     return (projection.project(point, { wkid: 4326 }) as Point)

--- a/widgets/get-map-coordinates-class/src/runtime/widget.tsx
+++ b/widgets/get-map-coordinates-class/src/runtime/widget.tsx
@@ -24,6 +24,7 @@ import { type IMConfig } from '../config'
 import { type JimuMapView, JimuMapViewComponent } from 'jimu-arcgis'
 
 import type Point from 'esri/geometry/Point'
+// import * as projection from 'esri/geometry/projection'
 
 import defaultMessages from './translations/default'
 
@@ -47,13 +48,21 @@ IState
     mapViewReady: false
   }
 
+  projectToWgs84 = (point: Point): Point => {
+    // if (point.spatialReference.isWGS84) {
+    //   return point
+    // }
+    // return (projection.project(point, { wkid: 4326 }) as Point)
+    return point
+  }
+
   activeViewChangeHandler = (jmv: JimuMapView) => {
     if (jmv) {
       // When the extent moves, update the state with all the updated values.
       jmv.view.watch('extent', evt => {
         this.setState({
-          latitude: jmv.view.center.latitude.toFixed(3),
-          longitude: jmv.view.center.longitude.toFixed(3),
+          latitude: this.projectToWgs84(jmv.view.center).latitude?.toFixed(3),
+          longitude: this.projectToWgs84(jmv.view.center).longitude?.toFixed(3),
           scale: Math.round(jmv.view.scale * 1) / 1,
           zoom: jmv.view.zoom,
           // this is set to false initially, then once we have the first set of data (and all subsequent) it's set
@@ -70,8 +79,8 @@ IState
           y: evt.y
         })
         this.setState({
-          latitude: point.latitude.toFixed(3),
-          longitude: point.longitude.toFixed(3),
+          latitude: this.projectToWgs84(point).latitude.toFixed(3),
+          longitude: this.projectToWgs84(point).longitude.toFixed(3),
           scale: Math.round(jmv.view.scale * 1) / 1,
           zoom: jmv.view.zoom,
           mapViewReady: true

--- a/widgets/get-map-coordinates-function/manifest.json
+++ b/widgets/get-map-coordinates-function/manifest.json
@@ -2,6 +2,7 @@
   "name": "get-map-coordinates-function",
   "label": "Get Map Coordinates (Function)",
   "type": "widget",
+  "dependency": "jimu-arcgis",
   "version": "1.13.0",
   "exbVersion": "1.13.0",
   "author": "Esri R&D Center Beijing",

--- a/widgets/get-map-coordinates-function/src/runtime/widget.tsx
+++ b/widgets/get-map-coordinates-function/src/runtime/widget.tsx
@@ -25,6 +25,7 @@ import { type IMConfig } from '../config'
 import { type JimuMapView, JimuMapViewComponent } from 'jimu-arcgis'
 
 import type Point from 'esri/geometry/Point'
+// import * as projection from 'esri/geometry/projection'
 
 import defaultMessages from './translations/default'
 
@@ -35,12 +36,20 @@ export default function (props: AllWidgetProps<IMConfig>) {
   const [scale, setScale] = useState<number>(0)
   const [mapViewReady, setMapViewReady] = useState<boolean>(false)
 
+  const projectToWgs84 = (point: Point): Point => {
+    // if (point.spatialReference.isWGS84) {
+    //   return point
+    // }
+    // return (projection.project(point, { wkid: 4326 }) as Point)
+    return point
+  }
+
   const activeViewChangeHandler = (jmv: JimuMapView) => {
     if (jmv) {
       // When the extent moves, update the state with all the updated values.
       jmv.view.watch('extent', evt => {
-        setLatitude(jmv.view.center.latitude.toFixed(3))
-        setLongitude(jmv.view.center.longitude.toFixed(3))
+        setLatitude(projectToWgs84(jmv.view.center).latitude?.toFixed(3))
+        setLongitude(projectToWgs84(jmv.view.center).longitude?.toFixed(3))
         setScale(Math.round(jmv.view.scale * 1) / 1)
         setZoom(jmv.view.zoom)
 
@@ -56,8 +65,8 @@ export default function (props: AllWidgetProps<IMConfig>) {
           x: evt.x,
           y: evt.y
         })
-        setLatitude(point.latitude.toFixed(3))
-        setLongitude(point.longitude.toFixed(3))
+        setLatitude(projectToWgs84(point).latitude?.toFixed(3))
+        setLongitude(projectToWgs84(point).longitude?.toFixed(3))
         setScale(Math.round(jmv.view.scale * 1) / 1)
         setZoom(jmv.view.zoom)
         setMapViewReady(true)

--- a/widgets/get-map-coordinates-function/src/runtime/widget.tsx
+++ b/widgets/get-map-coordinates-function/src/runtime/widget.tsx
@@ -25,7 +25,7 @@ import { type IMConfig } from '../config'
 import { type JimuMapView, JimuMapViewComponent } from 'jimu-arcgis'
 
 import type Point from 'esri/geometry/Point'
-// import * as projection from 'esri/geometry/projection'
+import * as projection from 'esri/geometry/projection'
 
 import defaultMessages from './translations/default'
 
@@ -36,20 +36,22 @@ export default function (props: AllWidgetProps<IMConfig>) {
   const [scale, setScale] = useState<number>(0)
   const [mapViewReady, setMapViewReady] = useState<boolean>(false)
 
-  const projectToWgs84 = (point: Point): Point => {
-    // if (point.spatialReference.isWGS84) {
-    //   return point
-    // }
-    // return (projection.project(point, { wkid: 4326 }) as Point)
-    return point
+  const projectToWgs84 = async (point: Point): Promise<Point> => {
+    if (point.spatialReference.isWGS84 || point.spatialReference.isWebMercator) {
+      return point
+    }
+    if (!projection.isLoaded) {
+      await projection.load()
+    }
+    return (projection.project(point, { wkid: 4326 }) as Point)
   }
 
   const activeViewChangeHandler = (jmv: JimuMapView) => {
     if (jmv) {
       // When the extent moves, update the state with all the updated values.
-      jmv.view.watch('extent', evt => {
-        setLatitude(projectToWgs84(jmv.view.center).latitude?.toFixed(3))
-        setLongitude(projectToWgs84(jmv.view.center).longitude?.toFixed(3))
+      jmv.view.watch('extent', async evt => {
+        setLatitude((await projectToWgs84(jmv.view.center)).latitude?.toFixed(3))
+        setLongitude((await projectToWgs84(jmv.view.center)).longitude?.toFixed(3))
         setScale(Math.round(jmv.view.scale * 1) / 1)
         setZoom(jmv.view.zoom)
 
@@ -60,13 +62,13 @@ export default function (props: AllWidgetProps<IMConfig>) {
 
       // When the pointer moves, take the pointer location and create a Point
       // Geometry out of it (`view.toMap(...)`), then update the state.
-      jmv.view.on('pointer-move', evt => {
+      jmv.view.on('pointer-move', async evt => {
         const point: Point = jmv.view.toMap({
           x: evt.x,
           y: evt.y
         })
-        setLatitude(projectToWgs84(point).latitude?.toFixed(3))
-        setLongitude(projectToWgs84(point).longitude?.toFixed(3))
+        setLatitude((await projectToWgs84(point)).latitude?.toFixed(3))
+        setLongitude((await projectToWgs84(point)).longitude?.toFixed(3))
         setScale(Math.round(jmv.view.scale * 1) / 1)
         setZoom(jmv.view.zoom)
         setMapViewReady(true)

--- a/widgets/get-map-coordinates-function/src/runtime/widget.tsx
+++ b/widgets/get-map-coordinates-function/src/runtime/widget.tsx
@@ -37,10 +37,10 @@ export default function (props: AllWidgetProps<IMConfig>) {
   const [mapViewReady, setMapViewReady] = useState<boolean>(false)
 
   const projectToWgs84 = async (point: Point): Promise<Point> => {
-    if (point.spatialReference.isWGS84 || point.spatialReference.isWebMercator) {
+    if (point.spatialReference.isWGS84 || point.spatialReference.isWebMercator)) {
       return point
     }
-    if (!projection.isLoaded) {
+    if (!projection.isLoaded()) {
       await projection.load()
     }
     return (projection.project(point, { wkid: 4326 }) as Point)


### PR DESCRIPTION
The "get map coordinates" widget ran into null pointer issues for SRs other than 4326 or 3857. latitude and longitude or map center resp. mouse coordinate are undefined when using a projected coordinate system like 25832 (UTM 32N). First step was to prevent the null pointer errors by adding conditional access (latitude?.toFixed(3)), second step was to project the points if necessary.