### PR TITLE
Fix sdk sample use coding components

### DIFF
--- a/widgets/use-coding-components/readme.md
+++ b/widgets/use-coding-components/readme.md
@@ -5,4 +5,4 @@ This sample demonstrates how to use `@arcgis/coding-components` in a widget.
 Clone the [sample repo](https://github.com/esri/arcgis-experience-builder-sdk-resources) and copy this widget's folder (within `widgets`) to the `client/your-extensions/widgets` folder of your Experience Builder installation.
 
 ## How it works
-This widget loads the coding components from CDN, and uses the component from `@arcgis/coding-components-react`
+This widget loads the coding components from CDN, and uses the component `arcgis-arcade-editor`

--- a/widgets/use-coding-components/readme.md
+++ b/widgets/use-coding-components/readme.md
@@ -5,4 +5,4 @@ This sample demonstrates how to use `@arcgis/coding-components` in a widget.
 Clone the [sample repo](https://github.com/esri/arcgis-experience-builder-sdk-resources) and copy this widget's folder (within `widgets`) to the `client/your-extensions/widgets` folder of your Experience Builder installation.
 
 ## How it works
-This widget loads the coding components from CDN, and uses the component `arcgis-arcade-editor`
+This widget loads the coding components from a CDN and uses the `ArcgisArcadeEditor` component by utilizing the `arcgis-arcade-editor`.

--- a/widgets/use-coding-components/readme.md
+++ b/widgets/use-coding-components/readme.md
@@ -5,4 +5,4 @@ This sample demonstrates how to use `@arcgis/coding-components` in a widget.
 Clone the [sample repo](https://github.com/esri/arcgis-experience-builder-sdk-resources) and copy this widget's folder (within `widgets`) to the `client/your-extensions/widgets` folder of your Experience Builder installation.
 
 ## How it works
-This widget loads the coding components from a CDN and uses the `ArcgisArcadeEditor` component by utilizing the `arcgis-arcade-editor`.
+This widget loads the coding components from a CDN and uses the `arcgis-arcade-editor` web component to render the Arcade editor.

--- a/widgets/use-coding-components/src/runtime/widget.tsx
+++ b/widgets/use-coding-components/src/runtime/widget.tsx
@@ -1,6 +1,5 @@
 import { moduleLoader, DataSourceComponent, type FeatureLayerDataSource, React, type AllWidgetProps, DataSourceManager, type IMDataSourceInfo, type FeatureDataRecord, type ArcGISQueryParams } from 'jimu-core'
 import 'calcite-components'
-import { ArcgisArcadeEditor } from '@arcgis/coding-components-react'
 
 const Widget = (props: AllWidgetProps<{ [key: string]: never }>) => {
   const ref = React.useRef(null)
@@ -65,7 +64,7 @@ const Widget = (props: AllWidgetProps<{ [key: string]: never }>) => {
   }
   return (
     <div className="jimu-widget m-2">
-      <ArcgisArcadeEditor ref={ref}/>
+      <arcgis-arcade-editor ref={ref}/>
       <DataSourceComponent
         useDataSource={useDs} query={{ outFields: ['*'] } as ArcGISQueryParams}
         widgetId={props.id}


### PR DESCRIPTION
Update `ArcgisArcadeEditor` component to use custom element syntax.
@qlqllu 