### PR TITLE
Fix get-map-coordinates props

### DIFF
--- a/widgets/get-map-coordinates-class/src/runtime/widget.tsx
+++ b/widgets/get-map-coordinates-class/src/runtime/widget.tsx
@@ -70,8 +70,8 @@ IState
           y: evt.y
         })
         this.setState({
-          latitude: point.latitude.toFixed(3),
-          longitude: point.longitude.toFixed(3),
+          latitude: point.x.toFixed(3),
+          longitude: point.y.toFixed(3),
           scale: Math.round(jmv.view.scale * 1) / 1,
           zoom: jmv.view.zoom,
           mapViewReady: true

--- a/widgets/get-map-coordinates-function/src/runtime/widget.tsx
+++ b/widgets/get-map-coordinates-function/src/runtime/widget.tsx
@@ -56,8 +56,8 @@ export default function (props: AllWidgetProps<IMConfig>) {
           x: evt.x,
           y: evt.y
         })
-        setLatitude(point.latitude.toFixed(3))
-        setLongitude(point.longitude.toFixed(3))
+        setLatitude(point.x.toFixed(3))
+        setLongitude(point.y.toFixed(3))
         setScale(Math.round(jmv.view.scale * 1) / 1)
         setZoom(jmv.view.zoom)
         setMapViewReady(true)


### PR DESCRIPTION
The [get-map-coordinates tutorial](https://developers.arcgis.com/experience-builder/guide/get-map-coordinates/) features code snippets in order to display the cursor's coordinates when hovering over the map. 

After following the steps, I ran into an error (_Uncaught TypeError: Cannot read properties of null (reading 'toFixed')_), so the lat/long values couldn't be displayed either. The 'completed widget' solution, that can be downloaded from the tutorial page, features the same code snippet: 

```
/** ADD: **/
const activeViewChangeHandler = (jmv: JimuMapView) => {
  if (jmv) {
    // When the pointer moves, take the pointer location and create a Point
    // Geometry out of it (`view.toMap(...)`), then update the state.
    jmv.view.on('pointer-move', (evt) => {
      const point: Point = jmv.view.toMap({
        x: evt.x,
        y: evt.y
      })
      setLatitude(point.latitude.toFixed(3))
      setLongitude(point.longitude.toFixed(3))
    })
  }
}
```

The changes in this PR should fix this error by using the correct properties to update the state, so the tutorial's outcome is functional. 